### PR TITLE
docs: clarify output formats and list modules

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -32,11 +32,13 @@ Construí una vez, convertí en cualquier lugar. 🚀
 
 - **100% en el cliente (privacidad)**: los archivos nunca salen del navegador.  
 - **Entrada**: archivos `.erdplus` o `.json` (el formato se detecta automáticamente).  
-- **Salida**: `name-old.erdplus` o `name-new.erdplus` según la dirección de conversión.  
+- **Salida**: archivo con la extensión que corresponda al formato de destino deseado (por ejemplo, `name-old.erdplus`, `schema.sql`, `schema.prisma`).  
 - **Relaciones**: dibuja un único enlace por cada FK (incluyendo compuestas) y lo ancla a las columnas hijas reales.  
 
 **Módulos disponibles**
 - ERDPlus Old ⇄ New (incluido)
+- SQL (DDL de PostgreSQL)
+- Prisma
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ Build once, convert everywhere. 🚀
 
 - **100% client side (privacy)**: files never leave the browser.
 - **Input**: `.erdplus` or `.json` files (format detected automatically).
-- **Output**: `name-old.erdplus` or `name-new.erdplus` depending on the conversion direction.
+- **Output**: file with the extension matching the desired target format (e.g., `name-old.erdplus`, `schema.sql`, `schema.prisma`).
 - **Relationships**: draws a single link for each FK (including composites) and anchors it to the actual child columns.
 
 **Available modules**
 - ERDPlus Old ⇄ New (bundled)
+- SQL (PostgreSQL DDL)
+- Prisma
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify README docs to state output extension depends on desired format
- list SQL and Prisma modules in both English and Spanish READMEs

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b7079e02c0832e8780a6c4e0ef039f