### PR TITLE
docs: remove optional testing sections from READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -286,17 +286,6 @@ Lee la [Guía de Contribución](CONTRIBUTING.es.md) antes de empezar.
 
 ---
 
-## 🧪 Testing (opcional)
-
-Si activás los tests (Vitest), podés validar los round‑trips:
-```bash
-npm run test
-```
-- **old → new → old**: deben conservarse tablas, atributos, posiciones y claves.
-- **new → old → new**: deben conservarse nodos, *edges* y columnas FK.
-
----
-
 ## ❓ FAQ
 
 **¿El conversor sube mis archivos?** No, todo corre en tu navegador.

--- a/README.md
+++ b/README.md
@@ -300,18 +300,6 @@ Please read the [Contributing Guide](CONTRIBUTING.md) before getting started.
 
 ---
 
-## 🧪 Testing (optional)
-
-If you enable tests (Vitest), you can validate round trips:
-```bash
-npm run test
-```
-- **old → new → old**: tables, attributes, positions and keys must be preserved.
-- **new → old → new**: nodes, edges and FK columns must be preserved.
-
-
----
-
 ## 🤝🏻 Top Contributors
 
 Thanks to everyone who contributes to the growth of this project. Your contribution can also be included here!


### PR DESCRIPTION
## Summary
- remove optional testing section from README.md
- remove optional testing section from README.es.md

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b711c8bc28832e8e3aab4d082adb11