### PR TITLE
docs: add tech badges and update project structure in readmes

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -9,8 +9,10 @@
 [Disponible en inglés](README.md) ✦ [Demo](https://erdus-inky.vercel.app) ✦ [Docs](https://deepwiki.com/tobiager/Erdus) ✦ [Contribuir](#-contribuyendo) ✦ [Roadmap](#%EF%B8%8F-roadmap-erdus--conversor-universal)
 
 **Un IR para mapearlos a todos.** Erdus es el **conversor universal open source** para diagramas ER y esquemas de bases de datos.  
-Unifica ERDPlus, SQL DDL, Prisma, JSON Schema y más bajo una estricta **Representación Intermedia (IR)**.  
+Unifica ERDPlus, SQL DDL, Prisma, JSON Schema y más bajo una estricta **Representación Intermedia (IR)**.
 Construí una vez, convertí en cualquier lugar. 🚀
+
+La interfaz web está construida con React mediante componentes TSX y utiliza Tailwind CSS para los estilos.
 
 </div>
 
@@ -22,6 +24,8 @@ Construí una vez, convertí en cualquier lugar. 🚀
 ![MIT](https://img.shields.io/badge/Licencia-MIT-FFF?labelColor=black&style=for-the-badge&color=1280ff)
 ![Vercel](https://img.shields.io/badge/Deploy-Vercel-FFF?labelColor=black&logo=vercel&style=for-the-badge&color=1280ff)
 
+![React](https://img.shields.io/badge/React-18.x-61DAFB?logo=react&logoColor=black&style=for-the-badge&labelColor=black)
+![TailwindCSS](https://img.shields.io/badge/TailwindCSS-3.x-06B6D4?logo=tailwindcss&logoColor=white&style=for-the-badge&labelColor=black)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white&style=for-the-badge&labelColor=black)
 ![Vite](https://img.shields.io/badge/Vite-5.x-646CFF?logo=vite&logoColor=white&style=for-the-badge&labelColor=black)
 ![Node](https://img.shields.io/badge/Node-≥18-339933?logo=node.js&logoColor=white&style=for-the-badge&labelColor=black)
@@ -47,18 +51,23 @@ https://github.com/user-attachments/assets/c1ae119b-651e-436d-a4a5-3f6c6e6eda2a
 
 ## 📁 Estructura del proyecto
 ```
-├─ src/
-│  ├─ app.ts           # UI: drag & drop, input de archivo, descarga
-│  ├─ convert.ts       # lógica de conversión old ⇄ new (sin pérdida)
-│  └─ types.ts         # tipos para ambos formatos (Old/New)
-├─ public/
-│  └─ favicon.svg
-├─ index.html          # landing mínima + dropzone
-├─ vite.config.ts
-├─ tsconfig.json
-├─ vercel.json
-├─ README.md
-└─ LICENSE
+.
+├── src/                # código fuente: CLI, conversores y web
+│   ├── components/     # componentes React reutilizables
+│   ├── pages/          # páginas de la aplicación
+│   ├── convert.ts      # lógica de conversión old ⇄ new
+│   └── ...             # otros módulos
+├── public/             # assets estáticos (favicon, etc.)
+├── docs/               # sitio de documentación
+├── examples/           # esquemas de ejemplo
+├── tests/              # pruebas unitarias
+├── assets/             # imágenes usadas en README/docs
+├── index.html          # landing mínima + dropzone
+├── vite.config.ts
+├── tailwind.config.ts
+├── tsconfig.json
+├── vercel.json
+└── LICENSE
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
 [Also available in Spanish](README.es.md) ✦ [Demo](https://erdus-inky.vercel.app) ✦ [Docs](https://deepwiki.com/tobiager/Erdus) ✦ [Contributing](#-contributing) ✦ [Roadmap](#%EF%B8%8F-roadmap--universal-converter)
 
 **One IR to map them all.** Erdus is the **open-source universal converter** for ER diagrams and database schemas.  
-It unifies ERDPlus, SQL DDL, Prisma, JSON Schema and more under a strict **Intermediate Representation (IR)**.  
+It unifies ERDPlus, SQL DDL, Prisma, JSON Schema and more under a strict **Intermediate Representation (IR)**.
 Build once, convert everywhere. 🚀
+
+The web interface is built with React using TSX components and styled with Tailwind CSS.
 
 </div>
 
@@ -22,6 +24,8 @@ Build once, convert everywhere. 🚀
 ![MIT](https://img.shields.io/badge/License-MIT-FFF?labelColor=black&style=for-the-badge&color=1280ff)
 ![Vercel](https://img.shields.io/badge/Deploy-Vercel-FFF?labelColor=black&logo=vercel&style=for-the-badge&color=1280ff)
 
+![React](https://img.shields.io/badge/React-18.x-61DAFB?logo=react&logoColor=black&style=for-the-badge&labelColor=black)
+![TailwindCSS](https://img.shields.io/badge/TailwindCSS-3.x-06B6D4?logo=tailwindcss&logoColor=white&style=for-the-badge&labelColor=black)
 ![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178C6?logo=typescript&logoColor=white&style=for-the-badge&labelColor=black)
 ![Vite](https://img.shields.io/badge/Vite-5.x-646CFF?logo=vite&logoColor=white&style=for-the-badge&labelColor=black)
 ![Node](https://img.shields.io/badge/Node-≥18-339933?logo=node.js&logoColor=white&style=for-the-badge&labelColor=black)
@@ -51,18 +55,22 @@ https://github.com/user-attachments/assets/c1ae119b-651e-436d-a4a5-3f6c6e6eda2a
 ## 📁 Project structure
 ```
 .
-├─ src/
-│  ├─ app.ts           # UI: drag & drop, file input, download
-│  ├─ convert.ts       # conversion logic old ⇄ new (lossless)
-│  └─ types.ts         # types for both formats (Old/New)
-├─ public/
-│  └─ favicon.svg
-├─ index.html          # minimal landing + dropzone
-├─ vite.config.ts
-├─ tsconfig.json
-├─ vercel.json
-├─ README.md
-└─ LICENSE
+├── src/                # source: CLI, converters and web UI
+│   ├── components/     # reusable React components
+│   ├── pages/          # application pages
+│   ├── convert.ts      # ERDPlus old ⇄ new conversion logic
+│   └── ...             # other modules
+├── public/             # static assets (favicon, etc.)
+├── docs/               # documentation site
+├── examples/           # example schemas
+├── tests/              # unit tests
+├── assets/             # images used in README/docs
+├── index.html          # minimal landing + dropzone
+├── vite.config.ts
+├── tailwind.config.ts
+├── tsconfig.json
+├── vercel.json
+└── LICENSE
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add React and Tailwind CSS badges alongside existing technology badges
- refresh project structure sections to reflect current layout

## Testing
- `pnpm lint` *(fails: Definition for rule 'react-hooks/exhaustive-deps' was not found)*
- `pnpm test`
- `pnpm typecheck` *(fails: Cannot find type definition file for 'react')*


------
https://chatgpt.com/codex/tasks/task_e_68b9debfeb0c832ebd003a2f35906eb0